### PR TITLE
Add Charlie Contributor to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@
 #    intellectual property rights related to this project.
 Anna Maintainer <anna@a.com>
 Bob Contributor <bob@b.com>
+Charlie Contributor <charlie@c.com>


### PR DESCRIPTION
The purpose of this pull request is to show that GitHub's merge button does not apply `.gitattributes` like `merge=union`. The same merge this pull requests proposes applied cleanly with CLI Git to produce 335aa4a9b2baded5a81283e50e5d82b8b138aafd.
